### PR TITLE
利用者はタスクの一覧が長くなっても見やすいようにしたい

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,1 +1,0 @@
-app/javascript/generated/graphql.ts linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@ db/schema.rb linguist-generated
 
 # Mark any vendored files as having been vendored.
 vendor/* linguist-vendored
+
+app/javascript/generated/graphql.ts linguist-generated
+schema.json linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ node_modules
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+data/redis*

--- a/app/graphql/queries/tasks.rb
+++ b/app/graphql/queries/tasks.rb
@@ -1,6 +1,6 @@
 module Queries
   class Tasks < Queries::AuthRequiredQuery
-    type [ObjectTypes::TaskType], null: false
+    type ObjectTypes::TaskType.connection_type, null: false
 
     def resolve
       current_user.tasks.order(limit_on: :asc, created_at: :desc)

--- a/app/javascript/components/TaskList.tsx
+++ b/app/javascript/components/TaskList.tsx
@@ -134,7 +134,7 @@ const TaskList: React.FC = () => {
               <div className="table-cell px-15">ステータス</div>
             </div>
           </div>
-          <div id="task-list" className="table-row-group">
+          <div className="table-row-group">
             {data?.tasks?.edges?.map((task) => (
               <div
                 className={`table-row text-center ${alert4limitOn(
@@ -176,9 +176,6 @@ const TaskList: React.FC = () => {
               variables: {
                 first: 10,
                 after: data?.tasks.pageInfo.endCursor,
-              },
-              updateQuery: (prevResult, { fetchMoreResult }) => {
-                return fetchMoreResult;
               },
             });
           }}

--- a/app/javascript/entrypoints/application.tsx
+++ b/app/javascript/entrypoints/application.tsx
@@ -6,6 +6,7 @@ import App from "../App";
 import "virtual:windi.css";
 import Cookies from "js-cookie";
 import { createUploadLink } from "apollo-upload-client";
+import { relayStylePagination } from "@apollo/client/utilities";
 
 const container = document.getElementById("root") as HTMLElement;
 const root = createRoot(container);
@@ -26,7 +27,18 @@ const client = new ApolloClient({
       uri: "/graphql",
     })
   ),
-  cache: new InMemoryCache(),
+  cache: new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          tasks: {
+            keyArgs: false,
+            merge: true,
+          },
+        },
+      },
+    },
+  }),
 });
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/app/javascript/generated/graphql.ts
+++ b/app/javascript/generated/graphql.ts
@@ -97,16 +97,36 @@ export type MutationUpdateTaskArgs = {
   input: UpdateTaskInput;
 };
 
+/** Information about pagination in a connection. */
+export type PageInfo = {
+  __typename?: "PageInfo";
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars["String"]>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars["Boolean"];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars["Boolean"];
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars["String"]>;
+};
+
 export type Query = {
   __typename?: "Query";
   statuses: Array<Status>;
   task: Task;
-  tasks: Array<Task>;
+  tasks: TaskConnection;
   users: Array<User>;
 };
 
 export type QueryTaskArgs = {
   id: Scalars["ID"];
+};
+
+export type QueryTasksArgs = {
+  after?: InputMaybe<Scalars["String"]>;
+  before?: InputMaybe<Scalars["String"]>;
+  first?: InputMaybe<Scalars["Int"]>;
+  last?: InputMaybe<Scalars["Int"]>;
 };
 
 export type Status = {
@@ -128,6 +148,26 @@ export type Task = {
   title: Scalars["String"];
   updatedAt: Scalars["ISO8601DateTime"];
   userId?: Maybe<Scalars["ID"]>;
+};
+
+/** The connection type for Task. */
+export type TaskConnection = {
+  __typename?: "TaskConnection";
+  /** A list of edges. */
+  edges?: Maybe<Array<Maybe<TaskEdge>>>;
+  /** A list of nodes. */
+  nodes?: Maybe<Array<Maybe<Task>>>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/** An edge in a connection. */
+export type TaskEdge = {
+  __typename?: "TaskEdge";
+  /** A cursor for use in pagination. */
+  cursor: Scalars["String"];
+  /** The item at the end of the edge. */
+  node?: Maybe<Task>;
 };
 
 export type TaskInput = {
@@ -260,18 +300,37 @@ export type FetchTaskByIdQuery = {
   };
 };
 
-export type FetchTasksQueryVariables = Exact<{ [key: string]: never }>;
+export type FetchTasksQueryVariables = Exact<{
+  first?: InputMaybe<Scalars["Int"]>;
+  last?: InputMaybe<Scalars["Int"]>;
+  before?: InputMaybe<Scalars["String"]>;
+  after?: InputMaybe<Scalars["String"]>;
+}>;
 
 export type FetchTasksQuery = {
   __typename?: "Query";
-  tasks: Array<{
-    __typename?: "Task";
-    id: string;
-    title: string;
-    detail?: string | null;
-    limitOn: any;
-    status?: { __typename?: "Status"; id: string; name: string } | null;
-  }>;
+  tasks: {
+    __typename?: "TaskConnection";
+    edges?: Array<{
+      __typename?: "TaskEdge";
+      cursor: string;
+      node?: {
+        __typename?: "Task";
+        id: string;
+        title: string;
+        detail?: string | null;
+        limitOn: any;
+        status?: { __typename?: "Status"; id: string; name: string } | null;
+      } | null;
+    } | null> | null;
+    pageInfo: {
+      __typename?: "PageInfo";
+      hasPreviousPage: boolean;
+      hasNextPage: boolean;
+      startCursor?: string | null;
+      endCursor?: string | null;
+    };
+  };
 };
 
 export type FetchUsersQueryVariables = Exact<{ [key: string]: never }>;
@@ -625,15 +684,26 @@ export type FetchTaskByIdQueryResult = Apollo.QueryResult<
   FetchTaskByIdQueryVariables
 >;
 export const FetchTasksDocument = gql`
-  query FetchTasks {
-    tasks {
-      id
-      title
-      detail
-      limitOn
-      status {
-        id
-        name
+  query FetchTasks($first: Int, $last: Int, $before: String, $after: String) {
+    tasks(first: $first, last: $last, before: $before, after: $after) {
+      edges {
+        cursor
+        node {
+          id
+          title
+          detail
+          limitOn
+          status {
+            id
+            name
+          }
+        }
+      }
+      pageInfo {
+        hasPreviousPage
+        hasNextPage
+        startCursor
+        endCursor
       }
     }
   }
@@ -651,6 +721,10 @@ export const FetchTasksDocument = gql`
  * @example
  * const { data, loading, error } = useFetchTasksQuery({
  *   variables: {
+ *      first: // value for 'first'
+ *      last: // value for 'last'
+ *      before: // value for 'before'
+ *      after: // value for 'after'
  *   },
  * });
  */

--- a/app/javascript/graphql/queries/tasks.ts
+++ b/app/javascript/graphql/queries/tasks.ts
@@ -1,15 +1,25 @@
 import { gql } from "@apollo/client";
 
 export const FETCH_TASKS = gql`
-  query FetchTasks {
-    tasks {
-      id
-      title
-      detail
-      limitOn
-      status {
-        id
-        name
+  query FetchTasks($first: Int, $last: Int, $before: String, $after: String) {
+    tasks(first: $first, last: $last, before: $before, after: $after) {
+      edges {
+        node {
+          id
+          title
+          detail
+          limitOn
+          status {
+            id
+            name
+          }
+        }
+      }
+      pageInfo {
+        hasPreviousPage
+        hasNextPage
+        startCursor
+        endCursor
       }
     }
   }

--- a/schema.graphql
+++ b/schema.graphql
@@ -106,10 +106,55 @@ type Mutation {
   ): UpdateTaskPayload
 }
 
+"""
+Information about pagination in a connection.
+"""
+type PageInfo {
+  """
+  When paginating forwards, the cursor to continue.
+  """
+  endCursor: String
+
+  """
+  When paginating forwards, are there more items?
+  """
+  hasNextPage: Boolean!
+
+  """
+  When paginating backwards, are there more items?
+  """
+  hasPreviousPage: Boolean!
+
+  """
+  When paginating backwards, the cursor to continue.
+  """
+  startCursor: String
+}
+
 type Query {
   statuses: [Status!]!
   task(id: ID!): Task!
-  tasks: [Task!]!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): TaskConnection!
   users: [User!]!
 }
 
@@ -130,6 +175,41 @@ type Task {
   title: String!
   updatedAt: ISO8601DateTime!
   userId: ID
+}
+
+"""
+The connection type for Task.
+"""
+type TaskConnection {
+  """
+  A list of edges.
+  """
+  edges: [TaskEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Task]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type TaskEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Task
 }
 
 input TaskInput {

--- a/schema.json
+++ b/schema.json
@@ -452,6 +452,83 @@
         },
         {
           "kind": "OBJECT",
+          "name": "PageInfo",
+          "description": "Information about pagination in a connection.",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "endCursor",
+              "description": "When paginating forwards, the cursor to continue.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "hasNextPage",
+              "description": "When paginating forwards, are there more items?",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "hasPreviousPage",
+              "description": "When paginating backwards, are there more items?",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "startCursor",
+              "description": "When paginating backwards, the cursor to continue.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Query",
           "description": null,
           "interfaces": [
@@ -525,23 +602,62 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Task",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "OBJECT",
+                  "name": "TaskConnection",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
               "deprecationReason": null,
               "args": [
-
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
               ]
             },
             {
@@ -816,6 +932,118 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TaskConnection",
+          "description": "The connection type for Task.",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TaskEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Task",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TaskEdge",
+          "description": "An edge in a connection.",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "node",
+              "description": "The item at the end of the edge.",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Task",
                 "ofType": null
               },
               "isDeprecated": false,


### PR DESCRIPTION
ストーリー
https://www.pivotaltracker.com/story/show/183449973
https://www.pivotaltracker.com/story/show/183756332


- カーソルベースでやってみる
- テストし易い件数ごとに取得する

参考
- https://graphql-ruby.org/pagination/using_connections.html
- https://note.com/tomo_program/n/nbb010ff6eede
- https://www.apollographql.com/docs/react/pagination/core-api/#the-fetchmore-function
- https://qiita.com/tera_shin/items/fa50625103356044f912