### PR TITLE
チームのタスクに利用者をアサインできる

### DIFF
--- a/app/graphql/input_types/task.rb
+++ b/app/graphql/input_types/task.rb
@@ -7,6 +7,6 @@ module InputTypes
     argument :limit_on, String, required: true
     argument :status_id, ID, required: true
     argument :user_id, ID, required: true
-    argument :team_id, ID, required: true
+    argument :team_id, ID
   end
 end

--- a/app/graphql/input_types/task.rb
+++ b/app/graphql/input_types/task.rb
@@ -8,5 +8,6 @@ module InputTypes
     argument :status_id, ID, required: true
     argument :user_id, ID, required: true
     argument :team_id, ID
+    argument :owner_id, ID
   end
 end

--- a/app/graphql/object_types/task_type.rb
+++ b/app/graphql/object_types/task_type.rb
@@ -13,5 +13,6 @@ module ObjectTypes
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     field :team_id, ID
     field :owner_id, ID
+    field :owner, ObjectTypes::UserType
   end
 end

--- a/app/graphql/object_types/task_type.rb
+++ b/app/graphql/object_types/task_type.rb
@@ -12,5 +12,6 @@ module ObjectTypes
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     field :team_id, ID
+    field :owner_id, ID
   end
 end

--- a/app/graphql/queries/team_users.rb
+++ b/app/graphql/queries/team_users.rb
@@ -1,0 +1,12 @@
+module Queries
+  class TeamUsers < Queries::AuthRequiredQuery
+    type [ObjectTypes::UserType], null: false
+
+    argument :team_id, ID, required: true
+
+    def resolve(team_id:, **args)
+      team_users = ::Team.find(team_id).users
+      team_users
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,5 +11,6 @@ module Types
     field :teams, resolver: Queries::Teams
     field :team, resolver: Queries::Team
     field :team_tasks, resolver: Queries::TeamTasks
+    field :team_users, resolver: Queries::TeamUsers
   end
 end

--- a/app/javascript/App.tsx
+++ b/app/javascript/App.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useState } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import NewTask from "./components/NewTask";
 import ErrorPage from "./components/ErrorPage";
@@ -38,7 +38,22 @@ interface AuthContextType {
   setCurrentUser: React.Dispatch<React.SetStateAction<User | undefined>>;
 }
 
+interface TeamContextType {
+  teamId: string;
+  setTeamId: (teamId: string) => void;
+}
+
 export const AuthContext = createContext<AuthContextType>(null!);
+
+export const TeamContext = createContext<TeamContextType>(null!);
+
+export const useSelectTeam = (): TeamContextType => {
+  const [teamId, setTeamId] = useState("");
+  return {
+    teamId,
+    setTeamId,
+  };
+};
 
 const App: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
@@ -77,23 +92,25 @@ const App: React.FC = () => {
           setCurrentUser,
         }}
       >
-        {!loading && (
-          <Routes>
-            <Route path="/signup" element={<SignUp />} />
-            <Route path="/signin" element={<SignIn />} />
-            <Route element={<RequireAuth />}>
-              <Route path="/" element={<TaskList />} />
-              <Route path="/tasks/:id" element={<Task />} />
-              <Route path="/tasks/new" element={<NewTask />} />
-              <Route path="/tasks/:id/edit" element={<EditTask />} />
-              <Route path="/users" element={<UserList />} />
-              <Route path="/teams/new" element={<NewTeam />} />
-              <Route path="/teams/:id" element={<Team />} />
-            </Route>
-            <Route path="/teams/:id/:token" element={<InviteTeam />} />
-            <Route path="*" element={<ErrorPage />} />
-          </Routes>
-        )}
+        <TeamContext.Provider value={useSelectTeam()}>
+          {!loading && (
+            <Routes>
+              <Route path="/signup" element={<SignUp />} />
+              <Route path="/signin" element={<SignIn />} />
+              <Route element={<RequireAuth />}>
+                <Route path="/" element={<TaskList />} />
+                <Route path="/tasks/:id" element={<Task />} />
+                <Route path="/tasks/new" element={<NewTask />} />
+                <Route path="/tasks/:id/edit" element={<EditTask />} />
+                <Route path="/users" element={<UserList />} />
+                <Route path="/teams/new" element={<NewTeam />} />
+                <Route path="/teams/:teamId" element={<Team />} />
+              </Route>
+              <Route path="/teams/:teamId/:token" element={<InviteTeam />} />
+              <Route path="*" element={<ErrorPage />} />
+            </Routes>
+          )}
+        </TeamContext.Provider>
       </AuthContext.Provider>
     </BrowserRouter>
   );

--- a/app/javascript/components/EditTask.tsx
+++ b/app/javascript/components/EditTask.tsx
@@ -1,9 +1,10 @@
 import React, { useContext, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { AuthContext } from "../App";
+import { AuthContext, TeamContext } from "../App";
 import {
   useFetchTaskByIdQuery,
   useUpdateTaskMutation,
+  useFetchTeamUsersQuery,
 } from "../generated/graphql";
 import SelectStatus from "./SelectStatus";
 
@@ -31,6 +32,14 @@ const EditTask: React.FC = () => {
   const [updateTask] = useUpdateTaskMutation({
     onCompleted: (data) => {
       navigate(`/tasks/${data?.updateTask?.task?.id}`);
+    },
+  });
+
+  const [ownerId, setOwnerId] = useState(data?.task.ownerId);
+  const team = useContext(TeamContext);
+  const { data: teamUsers } = useFetchTeamUsersQuery({
+    variables: {
+      teamId: team.teamId,
     },
   });
 
@@ -89,6 +98,29 @@ const EditTask: React.FC = () => {
           />
         </div>
         <SelectStatus statusId={statusId} changeStatus={changeStatus} />
+        <div className="mb-8">
+          <label
+            className="block text-gray-700 text-sm font-bold mb-2"
+            htmlFor="ownerId"
+          >
+            担当者
+          </label>
+          <select
+            className="shadow border rounded py-2 px-3"
+            name="ownerId"
+            value={ownerId}
+            onChange={(e) => {
+              setOwnerId(e.target.value);
+            }}
+          >
+            <option value="">未選択</option>
+            {teamUsers?.teamUsers.map((user) => (
+              <option key={user.id} value={user.id}>
+                {user.name}
+              </option>
+            ))}
+          </select>
+        </div>
         <div>
           <Link
             className="no-underline mr-2 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
@@ -102,13 +134,22 @@ const EditTask: React.FC = () => {
               void updateTask({
                 variables: {
                   id: params.id,
-                  params: { title, detail, limitOn, statusId, userId },
+                  params: {
+                    title,
+                    detail,
+                    limitOn,
+                    statusId,
+                    userId,
+                    teamId: team.teamId,
+                    ownerId,
+                  },
                 },
               });
               setTitle("");
               setDetail("");
               setLimitOn("");
               setStatusId("");
+              setOwnerId("");
             }}
           >
             更新

--- a/app/javascript/components/Header.tsx
+++ b/app/javascript/components/Header.tsx
@@ -2,12 +2,13 @@ import Cookies from "js-cookie";
 import React, { useContext } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { signOut } from "../api/auth";
-import { AuthContext } from "../App";
+import { AuthContext, TeamContext } from "../App";
 import { useFetchTeamsQuery } from "../generated/graphql";
 import NotificationToggle from "./NotificationToggle";
 
 const Header: React.FC = () => {
   const { setIsSignedIn, currentUser } = useContext(AuthContext);
+  const team = useContext(TeamContext);
   const navigate = useNavigate();
 
   const handleSignOut = async (): Promise<void> => {
@@ -32,8 +33,8 @@ const Header: React.FC = () => {
     }
   };
 
-  const params = useParams();
   const { data } = useFetchTeamsQuery();
+  const params = useParams();
 
   return (
     <div className="flex mx-4">
@@ -41,17 +42,18 @@ const Header: React.FC = () => {
         <select
           className="shadow border rounded py-2 px-3"
           name="teamId"
-          value={params.id}
+          value={params.teamId ?? team.teamId}
           onChange={(e) => {
             const teamId = e.target.value;
-            if (teamId === "0") {
+            team.setTeamId(teamId);
+            if (!teamId) {
               navigate("/");
             } else {
               navigate(`/teams/${teamId}`);
             }
           }}
         >
-          <option value="0">チーム未選択</option>
+          <option value="">チーム未選択</option>
           {data?.teams.map((team) => (
             <option key={team.id} value={team.id}>
               {team.name}

--- a/app/javascript/components/InviteTeam.tsx
+++ b/app/javascript/components/InviteTeam.tsx
@@ -16,7 +16,7 @@ const InviteTeam: React.FC = () => {
   const [message, setMessage] = useState("");
   const [participateTeamMutation] = useParticipateTeamMutation({
     variables: {
-      id: params.id,
+      id: params.teamId,
       token: params.token,
     },
     onCompleted: (data) => {

--- a/app/javascript/components/NewTask.tsx
+++ b/app/javascript/components/NewTask.tsx
@@ -1,17 +1,15 @@
 import React, { useContext, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { AuthContext } from "../App";
+import { AuthContext, TeamContext } from "../App";
 import {
   useCreateTaskMutation,
   useFetchStatusesQuery,
-  useFetchTeamsQuery,
 } from "../generated/graphql";
 
 const AddTask: React.FC = () => {
   const { currentUser } = useContext(AuthContext);
   const navigate = useNavigate();
   const { data } = useFetchStatusesQuery();
-  const { data: teamData } = useFetchTeamsQuery();
   const [createTask] = useCreateTaskMutation({
     onCompleted: (data) => {
       navigate(`/tasks/${data?.createTask?.task?.id}`);
@@ -21,7 +19,7 @@ const AddTask: React.FC = () => {
   const [detail, setDetail] = useState("");
   const [limitOn, setLimitOn] = useState("");
   const [statusId, setStatusId] = useState("1");
-  const [teamId, setTeamId] = useState("");
+  const team = useContext(TeamContext);
   const userId = currentUser?.id;
 
   return (
@@ -96,42 +94,26 @@ const AddTask: React.FC = () => {
             ))}
           </select>
         </div>
-        <div className="mb-8">
-          <label
-            className="block text-gray-700 text-sm font-bold mb-2"
-            htmlFor="teamId"
-          >
-            チーム
-          </label>
-          <select
-            className="shadow border rounded py-2 px-3"
-            name="teamId"
-            onChange={(e) => {
-              setTeamId(e.target.value);
-            }}
-          >
-            <option>未選択</option>
-            {teamData?.teams.map((team) => (
-              <option key={team.id} value={team.id}>
-                {team.name}
-              </option>
-            ))}
-          </select>
-        </div>
         <div>
           <button
             className="no-underline bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
             onClick={() => {
               void createTask({
                 variables: {
-                  params: { title, detail, limitOn, statusId, userId, teamId },
+                  params: {
+                    title,
+                    detail,
+                    limitOn,
+                    statusId,
+                    userId,
+                    teamId: team.teamId,
+                  },
                 },
               });
               setTitle("");
               setDetail("");
               setLimitOn("");
               setStatusId("");
-              setTeamId("");
             }}
           >
             追加

--- a/app/javascript/components/NewTask.tsx
+++ b/app/javascript/components/NewTask.tsx
@@ -4,6 +4,7 @@ import { AuthContext, TeamContext } from "../App";
 import {
   useCreateTaskMutation,
   useFetchStatusesQuery,
+  useFetchTeamUsersQuery,
 } from "../generated/graphql";
 
 const AddTask: React.FC = () => {
@@ -19,8 +20,15 @@ const AddTask: React.FC = () => {
   const [detail, setDetail] = useState("");
   const [limitOn, setLimitOn] = useState("");
   const [statusId, setStatusId] = useState("1");
+  const [ownerId, setOwnerId] = useState("");
   const team = useContext(TeamContext);
   const userId = currentUser?.id;
+
+  const { data: teamUsers } = useFetchTeamUsersQuery({
+    variables: {
+      teamId: team.teamId,
+    },
+  });
 
   return (
     <div className="container mx-auto">
@@ -94,6 +102,28 @@ const AddTask: React.FC = () => {
             ))}
           </select>
         </div>
+        <div className="mb-8">
+          <label
+            className="block text-gray-700 text-sm font-bold mb-2"
+            htmlFor="ownerId"
+          >
+            担当者
+          </label>
+          <select
+            className="shadow border rounded py-2 px-3"
+            name="ownerId"
+            onChange={(e) => {
+              setOwnerId(e.target.value);
+            }}
+          >
+            <option value="">未選択</option>
+            {teamUsers?.teamUsers.map((user) => (
+              <option key={user.id} value={user.id}>
+                {user.name}
+              </option>
+            ))}
+          </select>
+        </div>
         <div>
           <button
             className="no-underline bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
@@ -107,6 +137,7 @@ const AddTask: React.FC = () => {
                     statusId,
                     userId,
                     teamId: team.teamId,
+                    ownerId,
                   },
                 },
               });
@@ -114,6 +145,7 @@ const AddTask: React.FC = () => {
               setDetail("");
               setLimitOn("");
               setStatusId("");
+              setOwnerId("");
             }}
           >
             追加

--- a/app/javascript/components/Task.tsx
+++ b/app/javascript/components/Task.tsx
@@ -55,6 +55,7 @@ const Task: React.FC = () => {
       <div>詳細： {data?.task.detail}</div>
       <div>期限： {data?.task.limitOn}</div>
       <div>ステータス： {data?.task.status.name}</div>
+      <div>担当者：{data?.task.owner?.name}</div>
       <div className="text-center">
         <Link className="no-underline" to="/">
           - TOP -

--- a/app/javascript/components/TaskList.tsx
+++ b/app/javascript/components/TaskList.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { TeamContext } from "../App";
 import {
   useExportTaskMutation,
   useFetchTasksQuery,
@@ -55,6 +56,11 @@ export const alert4limitOn = (limit: string): string => {
 };
 
 const TaskList: React.FC = () => {
+  const team = useContext(TeamContext);
+  useEffect(() => {
+    team.setTeamId("");
+  }, []);
+
   const { loading, data, fetchMore } = useFetchTasksQuery({
     variables: {
       first: 10,

--- a/app/javascript/components/Team.tsx
+++ b/app/javascript/components/Team.tsx
@@ -11,12 +11,12 @@ const Team: React.FC = () => {
   const params = useParams();
   const { data } = useFetchTeamByIdQuery({
     variables: {
-      id: params.id,
+      id: params.teamId,
     },
     fetchPolicy: "cache-and-network",
   });
   const [email, setEmail] = useState("");
-  const [teamId, setTeamId] = useState(params.id);
+  const [teamId, setTeamId] = useState(params.teamId);
 
   const [sendInvitationMailMutation] = useSendInvitationMailMutation({
     variables: {
@@ -47,7 +47,7 @@ const Team: React.FC = () => {
   } = useFetchTeamTasksQuery({
     variables: {
       first: 10,
-      teamId: params.id,
+      teamId: params.teamId,
     },
   });
 
@@ -95,6 +95,14 @@ const Team: React.FC = () => {
           </div>
         </div>
       </form>
+      <div className="mb-5">
+        <Link
+          className="no-underline mr-2 bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
+          to="/tasks/new"
+        >
+          追加
+        </Link>
+      </div>
       {loading ? (
         <p>Loading ...</p>
       ) : (

--- a/app/javascript/generated/graphql.ts
+++ b/app/javascript/generated/graphql.ts
@@ -187,6 +187,7 @@ export type Query = {
   tasks: TaskConnection;
   team: Team;
   teamTasks: TaskConnection;
+  teamUsers: Array<User>;
   teams: Array<Team>;
   users: Array<User>;
 };
@@ -214,6 +215,10 @@ export type QueryTeamTasksArgs = {
   before?: InputMaybe<Scalars["String"]>;
   first?: InputMaybe<Scalars["Int"]>;
   last?: InputMaybe<Scalars["Int"]>;
+  teamId: Scalars["ID"];
+};
+
+export type QueryTeamUsersArgs = {
   teamId: Scalars["ID"];
 };
 
@@ -247,6 +252,7 @@ export type Task = {
   detail?: Maybe<Scalars["String"]>;
   id: Scalars["ID"];
   limitOn: Scalars["ISO8601Date"];
+  ownerId?: Maybe<Scalars["ID"]>;
   status?: Maybe<Status>;
   statusId?: Maybe<Scalars["ID"]>;
   teamId?: Maybe<Scalars["ID"]>;
@@ -278,6 +284,7 @@ export type TaskEdge = {
 export type TaskInput = {
   detail?: InputMaybe<Scalars["String"]>;
   limitOn: Scalars["String"];
+  ownerId: Scalars["ID"];
   statusId: Scalars["ID"];
   teamId: Scalars["ID"];
   title: Scalars["String"];
@@ -364,6 +371,7 @@ export type CreateTaskMutation = {
       statusId?: string | null;
       userId?: string | null;
       teamId?: string | null;
+      ownerId?: string | null;
     };
   } | null;
 };
@@ -459,6 +467,9 @@ export type UpdateTaskMutation = {
       detail?: string | null;
       limitOn: any;
       statusId?: string | null;
+      userId?: string | null;
+      teamId?: string | null;
+      ownerId?: string | null;
     };
   } | null;
 };
@@ -564,6 +575,15 @@ export type FetchTeamTasksQuery = {
   };
 };
 
+export type FetchTeamUsersQueryVariables = Exact<{
+  teamId: Scalars["ID"];
+}>;
+
+export type FetchTeamUsersQuery = {
+  __typename?: "Query";
+  teamUsers: Array<{ __typename?: "User"; id: string; name?: string | null }>;
+};
+
 export type FetchTeamsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type FetchTeamsQuery = {
@@ -599,6 +619,7 @@ export const CreateTaskDocument = gql`
         statusId
         userId
         teamId
+        ownerId
       }
     }
   }
@@ -1010,6 +1031,9 @@ export const UpdateTaskDocument = gql`
         detail
         limitOn
         statusId
+        userId
+        teamId
+        ownerId
       }
     }
   }
@@ -1426,6 +1450,65 @@ export type FetchTeamTasksLazyQueryHookResult = ReturnType<
 export type FetchTeamTasksQueryResult = Apollo.QueryResult<
   FetchTeamTasksQuery,
   FetchTeamTasksQueryVariables
+>;
+export const FetchTeamUsersDocument = gql`
+  query FetchTeamUsers($teamId: ID!) {
+    teamUsers(teamId: $teamId) {
+      id
+      name
+    }
+  }
+`;
+
+/**
+ * __useFetchTeamUsersQuery__
+ *
+ * To run a query within a React component, call `useFetchTeamUsersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFetchTeamUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFetchTeamUsersQuery({
+ *   variables: {
+ *      teamId: // value for 'teamId'
+ *   },
+ * });
+ */
+export function useFetchTeamUsersQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    FetchTeamUsersQuery,
+    FetchTeamUsersQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<FetchTeamUsersQuery, FetchTeamUsersQueryVariables>(
+    FetchTeamUsersDocument,
+    options
+  );
+}
+export function useFetchTeamUsersLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    FetchTeamUsersQuery,
+    FetchTeamUsersQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<FetchTeamUsersQuery, FetchTeamUsersQueryVariables>(
+    FetchTeamUsersDocument,
+    options
+  );
+}
+export type FetchTeamUsersQueryHookResult = ReturnType<
+  typeof useFetchTeamUsersQuery
+>;
+export type FetchTeamUsersLazyQueryHookResult = ReturnType<
+  typeof useFetchTeamUsersLazyQuery
+>;
+export type FetchTeamUsersQueryResult = Apollo.QueryResult<
+  FetchTeamUsersQuery,
+  FetchTeamUsersQueryVariables
 >;
 export const FetchTeamsDocument = gql`
   query FetchTeams {

--- a/app/javascript/generated/graphql.ts
+++ b/app/javascript/generated/graphql.ts
@@ -252,6 +252,7 @@ export type Task = {
   detail?: Maybe<Scalars["String"]>;
   id: Scalars["ID"];
   limitOn: Scalars["ISO8601Date"];
+  owner?: Maybe<User>;
   ownerId?: Maybe<Scalars["ID"]>;
   status?: Maybe<Status>;
   statusId?: Maybe<Scalars["ID"]>;
@@ -494,7 +495,9 @@ export type FetchTaskByIdQuery = {
     detail?: string | null;
     limitOn: any;
     statusId?: string | null;
+    ownerId?: string | null;
     status?: { __typename?: "Status"; id: string; name: string } | null;
+    owner?: { __typename?: "User"; id: string; name?: string | null } | null;
   };
 };
 
@@ -1148,7 +1151,12 @@ export const FetchTaskByIdDocument = gql`
       detail
       limitOn
       statusId
+      ownerId
       status {
+        id
+        name
+      }
+      owner {
         id
         name
       }

--- a/app/javascript/graphql/mutations/createTask.ts
+++ b/app/javascript/graphql/mutations/createTask.ts
@@ -11,6 +11,7 @@ export const CREATE_TASK = gql`
         statusId
         userId
         teamId
+        ownerId
       }
     }
   }

--- a/app/javascript/graphql/mutations/updateTask.ts
+++ b/app/javascript/graphql/mutations/updateTask.ts
@@ -9,6 +9,9 @@ export const UPDATE_TASK = gql`
         detail
         limitOn
         statusId
+        userId
+        teamId
+        ownerId
       }
     }
   }

--- a/app/javascript/graphql/queries/task.ts
+++ b/app/javascript/graphql/queries/task.ts
@@ -8,7 +8,12 @@ export const FETCH_TASK_BY_ID = gql`
       detail
       limitOn
       statusId
+      ownerId
       status {
+        id
+        name
+      }
+      owner {
         id
         name
       }

--- a/app/javascript/graphql/queries/team_users.ts
+++ b/app/javascript/graphql/queries/team_users.ts
@@ -1,0 +1,10 @@
+import { gql } from "@apollo/client";
+
+export const FETCH_TEAM_USERS = gql`
+  query FetchTeamUsers($teamId: ID!) {
+    teamUsers(teamId: $teamId) {
+      id
+      name
+    }
+  }
+`;

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,5 @@ class Task < ApplicationRecord
   belongs_to :status, optional: true
   belongs_to :user, optional: true
   belongs_to :team, optional: true
+  belongs_to :owner, class_name: "User", foreign_key: "owner_id", optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ActiveRecord::Base
   has_many :created_teams, class_name: "Team", foreign_key: "owner_id"
   has_many :team_users
   has_many :teams, through: :team_users
+  has_many :own_tasks, class_name: "User", foreign_key: "owner_id"
   enum role: {general: 0, admin: 1}
   enum notification_flg: {disabled: 0, enabled: 1}
 end

--- a/db/migrate/20221125083701_add_owner_id_to_tasks.rb
+++ b/db/migrate/20221125083701_add_owner_id_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddOwnerIdToTasks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tasks, :owner_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_24_013323) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_25_083701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,6 +71,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_24_013323) do
     t.bigint "status_id"
     t.bigint "user_id"
     t.bigint "team_id"
+    t.integer "owner_id"
     t.index ["status_id"], name: "index_tasks_on_status_id"
     t.index ["team_id"], name: "index_tasks_on_team_id"
     t.index ["user_id"], name: "index_tasks_on_user_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -317,6 +317,7 @@ type Task {
   detail: String
   id: ID!
   limitOn: ISO8601Date!
+  owner: User
   ownerId: ID
   status: Status
   statusId: ID

--- a/schema.graphql
+++ b/schema.graphql
@@ -277,6 +277,7 @@ type Query {
     last: Int
     teamId: ID!
   ): TaskConnection!
+  teamUsers(teamId: ID!): [User!]!
   teams: [Team!]!
   users: [User!]!
 }
@@ -316,6 +317,7 @@ type Task {
   detail: String
   id: ID!
   limitOn: ISO8601Date!
+  ownerId: ID
   status: Status
   statusId: ID
   teamId: ID
@@ -362,6 +364,7 @@ type TaskEdge {
 input TaskInput {
   detail: String
   limitOn: String!
+  ownerId: ID!
   statusId: ID!
   teamId: ID!
   title: String!

--- a/schema.json
+++ b/schema.json
@@ -1573,6 +1573,20 @@
               ]
             },
             {
+              "name": "owner",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "ownerId",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -1204,6 +1204,47 @@
               ]
             },
             {
+              "name": "teamUsers",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "User",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "teamId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "teams",
               "description": null,
               "type": {
@@ -1532,6 +1573,20 @@
               ]
             },
             {
+              "name": "ownerId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "status",
               "description": null,
               "type": {
@@ -1825,6 +1880,22 @@
             },
             {
               "name": "teamId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ownerId",
               "description": null,
               "type": {
                 "kind": "NON_NULL",


### PR DESCRIPTION
ストーリー
https://www.pivotaltracker.com/story/show/183811485

- チーム画面でタスク追加するときにチームのメンバーが選択できるようにする
- 個人用のタスク一覧画面の追加ではチーム選択をなくす
  - チーム画面からの追加にすることでチーム選択は不要とする