### PR TITLE
利用者は自分がアサインされているチームタスクのみ表示できる

### DIFF
--- a/app/graphql/queries/team_tasks.rb
+++ b/app/graphql/queries/team_tasks.rb
@@ -3,11 +3,13 @@ module Queries
     type ObjectTypes::TaskType.connection_type, null: false
 
     argument :team_id, ID, required: true
+    argument :owner_id, ID, required: false
 
-    def resolve(team_id:, **args)
+    def resolve(team_id:, owner_id: nil, **args)
       tasks = current_user.tasks
                             .where(team_id: team_id)
                             .order(limit_on: :asc, created_at: :desc)
+      tasks = tasks.where(owner_id: owner_id) if owner_id.present?
       tasks
     end
   end

--- a/app/javascript/components/TaskList.tsx
+++ b/app/javascript/components/TaskList.tsx
@@ -6,6 +6,7 @@ import {
   useFetchTasksQuery,
   useImportTaskMutation,
 } from "../generated/graphql";
+import Tasks from "./Tasks";
 
 /**
  * Dateオブジェクトの時刻丸め関数
@@ -252,72 +253,7 @@ const TaskList: React.FC = () => {
           }}
         />
       </div>
-      {loading ? (
-        <p>Loading ...</p>
-      ) : (
-        <div className="table">
-          <div className="table-header-group">
-            <div className="table-row text-center">
-              <div className="table-cell px-40">タイトル</div>
-              <div className="table-cell px-15">期限</div>
-              <div className="table-cell px-15">ステータス</div>
-            </div>
-          </div>
-          <div className="table-row-group">
-            {data?.tasks?.edges?.map((task) => (
-              <div
-                className={`table-row text-center ${alert4limitOn(
-                  task.node.limitOn
-                )}`}
-                key={task.node.id}
-              >
-                <div className="table-cell">
-                  <Link to={`/tasks/${task.node.id}`}>{task.node.title}</Link>
-                </div>
-                <div className="table-cell">{task.node.limitOn}</div>
-                <div className="table-cell">{task.node.status.name}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-      <div className="mt-5 text-center">
-        <button
-          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
-          disabled={!(data?.tasks.pageInfo.hasPreviousPage ?? false)}
-          onClick={() => {
-            void fetchMore({
-              variables: {
-                first: null,
-                last: 10,
-                before: data?.tasks.pageInfo.startCursor,
-                from: fromLimitOn,
-                to: toLimitOn,
-                title,
-              },
-            });
-          }}
-        >
-          ←前の10件
-        </button>
-        <button
-          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
-          disabled={!(data?.tasks.pageInfo.hasNextPage ?? false)}
-          onClick={() => {
-            void fetchMore({
-              variables: {
-                first: 10,
-                after: data?.tasks.pageInfo.endCursor,
-                from: fromLimitOn,
-                to: toLimitOn,
-                title,
-              },
-            });
-          }}
-        >
-          次の10件→
-        </button>
-      </div>
+      <Tasks data={data?.tasks} loading={loading} fetchMore={fetchMore} />
     </div>
   );
 };

--- a/app/javascript/components/Tasks.tsx
+++ b/app/javascript/components/Tasks.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { TaskConnection } from "../generated/graphql";
+import { alert4limitOn } from "./TaskList";
+import { FetchMoreOptions } from "@apollo/client";
+
+interface Props {
+  data: TaskConnection;
+  loading: boolean;
+  fetchMore: (variables: FetchMoreOptions) => void;
+}
+
+const Tasks: React.FC<Props> = (props: Props) => {
+  return (
+    <>
+      {props.loading ? (
+        <p>Loading ...</p>
+      ) : (
+        <div className="table">
+          <div className="table-header-group">
+            <div className="table-row text-center">
+              <div className="table-cell px-40">タイトル</div>
+              <div className="table-cell px-15">期限</div>
+              <div className="table-cell px-15">ステータス</div>
+            </div>
+          </div>
+          <div className="table-row-group">
+            {props.data.edges?.map((task) => (
+              <div
+                className={`table-row text-center ${alert4limitOn(
+                  task.node.limitOn
+                )}`}
+                key={task?.node?.id}
+              >
+                <div className="table-cell">
+                  <Link to={`/tasks/${task?.node.id}`}>
+                    {task?.node?.title}
+                  </Link>
+                </div>
+                <div className="table-cell">{task?.node?.limitOn}</div>
+                <div className="table-cell">{task?.node?.status?.name}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="mt-5 text-center">
+        <button
+          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
+          disabled={!(props.data?.pageInfo?.hasPreviousPage ?? false)}
+          onClick={() => {
+            void props?.fetchMore({
+              variables: {
+                first: null,
+                last: 10,
+                before: props.data?.pageInfo?.startCursor,
+              },
+            });
+          }}
+        >
+          ←前の10件
+        </button>
+        <button
+          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
+          disabled={!(props.data?.pageInfo?.hasNextPage ?? false)}
+          onClick={() => {
+            void props?.fetchMore({
+              variables: {
+                first: 10,
+                after: props.data?.pageInfo?.endCursor,
+              },
+            });
+          }}
+        >
+          次の10件→
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default Tasks;

--- a/app/javascript/components/Team.tsx
+++ b/app/javascript/components/Team.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { AuthContext } from "../App";
 import {
   useFetchTeamByIdQuery,
   useFetchTeamTasksQuery,
@@ -8,6 +9,7 @@ import {
 import { alert4limitOn } from "./TaskList";
 
 const Team: React.FC = () => {
+  const { currentUser } = useContext(AuthContext);
   const params = useParams();
   const { data } = useFetchTeamByIdQuery({
     variables: {
@@ -49,6 +51,7 @@ const Team: React.FC = () => {
       first: 10,
       teamId: params.teamId,
     },
+    fetchPolicy: "cache-and-network",
   });
 
   return (
@@ -102,6 +105,29 @@ const Team: React.FC = () => {
         >
           追加
         </Link>
+        <div className="inline-block">
+          <label
+            className="block text-gray-700 text-sm font-bold mb-2"
+            htmlFor="ownerId"
+          >
+            担当者
+          </label>
+          <select
+            className="shadow border rounded py-2 px-3"
+            name="ownerId"
+            onChange={(e) => {
+              void fetchMore({
+                variables: {
+                  first: 10,
+                  ownerId: e.target.value,
+                },
+              });
+            }}
+          >
+            <option value="">未選択</option>
+            <option value={currentUser?.id}>自分</option>
+          </select>
+        </div>
       </div>
       {loading ? (
         <p>Loading ...</p>

--- a/app/javascript/components/Team.tsx
+++ b/app/javascript/components/Team.tsx
@@ -7,6 +7,7 @@ import {
   useSendInvitationMailMutation,
 } from "../generated/graphql";
 import { alert4limitOn } from "./TaskList";
+import Tasks from "./Tasks";
 
 const Team: React.FC = () => {
   const { currentUser } = useContext(AuthContext);
@@ -129,66 +130,7 @@ const Team: React.FC = () => {
           </select>
         </div>
       </div>
-      {loading ? (
-        <p>Loading ...</p>
-      ) : (
-        <div className="table">
-          <div className="table-header-group">
-            <div className="table-row text-center">
-              <div className="table-cell px-40">タイトル</div>
-              <div className="table-cell px-15">期限</div>
-              <div className="table-cell px-15">ステータス</div>
-            </div>
-          </div>
-          <div className="table-row-group">
-            {team?.teamTasks?.edges?.map((task) => (
-              <div
-                className={`table-row text-center ${alert4limitOn(
-                  task.node.limitOn
-                )}`}
-                key={task.node.id}
-              >
-                <div className="table-cell">
-                  <Link to={`/tasks/${task.node.id}`}>{task.node.title}</Link>
-                </div>
-                <div className="table-cell">{task.node.limitOn}</div>
-                <div className="table-cell">{task.node.status.name}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-      <div className="mt-5 text-center">
-        <button
-          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
-          disabled={!(team?.teamTasks.pageInfo.hasPreviousPage ?? false)}
-          onClick={() => {
-            void fetchMore({
-              variables: {
-                first: null,
-                last: 10,
-                before: team?.teamTasks.pageInfo.startCursor,
-              },
-            });
-          }}
-        >
-          ←前の10件
-        </button>
-        <button
-          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
-          disabled={!(team?.teamTasks.pageInfo.hasNextPage ?? false)}
-          onClick={() => {
-            void fetchMore({
-              variables: {
-                first: 10,
-                after: team?.teamTasks.pageInfo.endCursor,
-              },
-            });
-          }}
-        >
-          次の10件→
-        </button>
-      </div>
+      <Tasks data={team?.teamTasks} loading={loading} fetchMore={fetchMore} />
       <div className="text-center">
         <Link className="no-underline" to="/">
           - TOP -

--- a/app/javascript/entrypoints/application.tsx
+++ b/app/javascript/entrypoints/application.tsx
@@ -35,6 +35,10 @@ const client = new ApolloClient({
             keyArgs: false,
             merge: true,
           },
+          teamTasks: {
+            keyArgs: false,
+            merge: true,
+          },
         },
       },
     },

--- a/app/javascript/generated/graphql.ts
+++ b/app/javascript/generated/graphql.ts
@@ -215,6 +215,7 @@ export type QueryTeamTasksArgs = {
   before?: InputMaybe<Scalars["String"]>;
   first?: InputMaybe<Scalars["Int"]>;
   last?: InputMaybe<Scalars["Int"]>;
+  ownerId?: InputMaybe<Scalars["ID"]>;
   teamId: Scalars["ID"];
 };
 
@@ -551,6 +552,7 @@ export type FetchTeamTasksQueryVariables = Exact<{
   before?: InputMaybe<Scalars["String"]>;
   after?: InputMaybe<Scalars["String"]>;
   teamId: Scalars["ID"];
+  ownerId?: InputMaybe<Scalars["ID"]>;
 }>;
 
 export type FetchTeamTasksQuery = {
@@ -1375,6 +1377,7 @@ export const FetchTeamTasksDocument = gql`
     $before: String
     $after: String
     $teamId: ID!
+    $ownerId: ID
   ) {
     teamTasks(
       first: $first
@@ -1382,6 +1385,7 @@ export const FetchTeamTasksDocument = gql`
       before: $before
       after: $after
       teamId: $teamId
+      ownerId: $ownerId
     ) {
       edges {
         node {
@@ -1422,6 +1426,7 @@ export const FetchTeamTasksDocument = gql`
  *      before: // value for 'before'
  *      after: // value for 'after'
  *      teamId: // value for 'teamId'
+ *      ownerId: // value for 'ownerId'
  *   },
  * });
  */

--- a/app/javascript/graphql/queries/team_tasks.ts
+++ b/app/javascript/graphql/queries/team_tasks.ts
@@ -7,6 +7,7 @@ export const FETCH_TEAM_TASKS = gql`
     $before: String
     $after: String
     $teamId: ID!
+    $ownerId: ID
   ) {
     teamTasks(
       first: $first
@@ -14,6 +15,7 @@ export const FETCH_TEAM_TASKS = gql`
       before: $before
       after: $after
       teamId: $teamId
+      ownerId: $ownerId
     ) {
       edges {
         node {

--- a/schema.graphql
+++ b/schema.graphql
@@ -275,6 +275,7 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+    ownerId: ID
     teamId: ID!
   ): TaskConnection!
   teamUsers(teamId: ID!): [User!]!

--- a/schema.json
+++ b/schema.json
@@ -1154,6 +1154,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "ownerId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "after",
                   "description": "Returns the elements in the list that come after the specified cursor.",
                   "type": {


### PR DESCRIPTION
ストーリー
https://www.pivotaltracker.com/story/show/183811501

チーム画面でアサインされたタスクに絞り込めるようにドロップダウンを設置しました。
- 未選択 → チームのタスクが全て一覧表示される
- 自分 → 自分がアサインされたタスクのみ一覧表示される

![スクリーンショット 2022-11-28 14 25 19](https://user-images.githubusercontent.com/45804846/204200700-459f668d-7646-4308-882a-8817ee2d1b6f.png)
