### PR TITLE
タスク一覧のコンポーネント化

### DIFF
--- a/app/javascript/components/TaskList.tsx
+++ b/app/javascript/components/TaskList.tsx
@@ -6,6 +6,7 @@ import {
   useFetchTasksQuery,
   useImportTaskMutation,
 } from "../generated/graphql";
+import Tasks from "./Tasks";
 
 /**
  * Dateオブジェクトの時刻丸め関数
@@ -252,72 +253,7 @@ const TaskList: React.FC = () => {
           }}
         />
       </div>
-      {loading ? (
-        <p>Loading ...</p>
-      ) : (
-        <div className="table">
-          <div className="table-header-group">
-            <div className="table-row text-center">
-              <div className="table-cell px-40">タイトル</div>
-              <div className="table-cell px-15">期限</div>
-              <div className="table-cell px-15">ステータス</div>
-            </div>
-          </div>
-          <div className="table-row-group">
-            {data?.tasks?.edges?.map((task) => (
-              <div
-                className={`table-row text-center ${alert4limitOn(
-                  task.node.limitOn
-                )}`}
-                key={task.node.id}
-              >
-                <div className="table-cell">
-                  <Link to={`/tasks/${task.node.id}`}>{task.node.title}</Link>
-                </div>
-                <div className="table-cell">{task.node.limitOn}</div>
-                <div className="table-cell">{task.node.status.name}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-      <div className="mt-5 text-center">
-        <button
-          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
-          disabled={!(data?.tasks.pageInfo.hasPreviousPage ?? false)}
-          onClick={() => {
-            void fetchMore({
-              variables: {
-                first: null,
-                last: 10,
-                before: data?.tasks.pageInfo.startCursor,
-                from: fromLimitOn,
-                to: toLimitOn,
-                title,
-              },
-            });
-          }}
-        >
-          ←前の10件
-        </button>
-        <button
-          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
-          disabled={!(data?.tasks.pageInfo.hasNextPage ?? false)}
-          onClick={() => {
-            void fetchMore({
-              variables: {
-                first: 10,
-                after: data?.tasks.pageInfo.endCursor,
-                from: fromLimitOn,
-                to: toLimitOn,
-                title,
-              },
-            });
-          }}
-        >
-          次の10件→
-        </button>
-      </div>
+      <Tasks data={data?.tasks} loading={loading} fetchMore={fetchMore} />
     </div>
   );
 };

--- a/app/javascript/components/Tasks.tsx
+++ b/app/javascript/components/Tasks.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { TaskConnection } from "../generated/graphql";
+import { alert4limitOn } from "./TaskList";
+import { FetchMoreOptions } from "@apollo/client";
+
+interface Props {
+  data: TaskConnection;
+  loading: boolean;
+  fetchMore: (variables: FetchMoreOptions) => void;
+}
+
+const Tasks: React.FC<Props> = (props: Props) => {
+  return (
+    <>
+      {props.loading ? (
+        <p>Loading ...</p>
+      ) : (
+        <div className="table">
+          <div className="table-header-group">
+            <div className="table-row text-center">
+              <div className="table-cell px-40">タイトル</div>
+              <div className="table-cell px-15">期限</div>
+              <div className="table-cell px-15">ステータス</div>
+            </div>
+          </div>
+          <div className="table-row-group">
+            {props.data.edges?.map((task) => (
+              <div
+                className={`table-row text-center ${alert4limitOn(
+                  task.node.limitOn
+                )}`}
+                key={task?.node?.id}
+              >
+                <div className="table-cell">
+                  <Link to={`/tasks/${task?.node.id}`}>
+                    {task?.node?.title}
+                  </Link>
+                </div>
+                <div className="table-cell">{task?.node?.limitOn}</div>
+                <div className="table-cell">{task?.node?.status?.name}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="mt-5 text-center">
+        <button
+          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
+          disabled={!(props.data?.pageInfo?.hasPreviousPage ?? false)}
+          onClick={() => {
+            void props?.fetchMore({
+              variables: {
+                first: null,
+                last: 10,
+                before: props.data?.pageInfo?.startCursor,
+              },
+            });
+          }}
+        >
+          ←前の10件
+        </button>
+        <button
+          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
+          disabled={!(props.data?.pageInfo?.hasNextPage ?? false)}
+          onClick={() => {
+            void props?.fetchMore({
+              variables: {
+                first: 10,
+                after: props.data?.pageInfo?.endCursor,
+              },
+            });
+          }}
+        >
+          次の10件→
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default Tasks;

--- a/app/javascript/components/Team.tsx
+++ b/app/javascript/components/Team.tsx
@@ -7,6 +7,7 @@ import {
   useSendInvitationMailMutation,
 } from "../generated/graphql";
 import { alert4limitOn } from "./TaskList";
+import Tasks from "./Tasks";
 
 const Team: React.FC = () => {
   const { currentUser } = useContext(AuthContext);
@@ -129,66 +130,7 @@ const Team: React.FC = () => {
           </select>
         </div>
       </div>
-      {loading ? (
-        <p>Loading ...</p>
-      ) : (
-        <div className="table">
-          <div className="table-header-group">
-            <div className="table-row text-center">
-              <div className="table-cell px-40">タイトル</div>
-              <div className="table-cell px-15">期限</div>
-              <div className="table-cell px-15">ステータス</div>
-            </div>
-          </div>
-          <div className="table-row-group">
-            {team?.teamTasks?.edges?.map((task) => (
-              <div
-                className={`table-row text-center ${alert4limitOn(
-                  task.node.limitOn
-                )}`}
-                key={task.node.id}
-              >
-                <div className="table-cell">
-                  <Link to={`/tasks/${task.node.id}`}>{task.node.title}</Link>
-                </div>
-                <div className="table-cell">{task.node.limitOn}</div>
-                <div className="table-cell">{task.node.status.name}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-      <div className="mt-5 text-center">
-        <button
-          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
-          disabled={!(team?.teamTasks.pageInfo.hasPreviousPage ?? false)}
-          onClick={() => {
-            void fetchMore({
-              variables: {
-                first: null,
-                last: 10,
-                before: team?.teamTasks.pageInfo.startCursor,
-              },
-            });
-          }}
-        >
-          ←前の10件
-        </button>
-        <button
-          className="m-2 p-2 font-bold border rounded disabled:bg-slate-50 disabled:text-slate-500"
-          disabled={!(team?.teamTasks.pageInfo.hasNextPage ?? false)}
-          onClick={() => {
-            void fetchMore({
-              variables: {
-                first: 10,
-                after: team?.teamTasks.pageInfo.endCursor,
-              },
-            });
-          }}
-        >
-          次の10件→
-        </button>
-      </div>
+      <Tasks data={team?.teamTasks} loading={loading} fetchMore={fetchMore} />
       <div className="text-center">
         <Link className="no-underline" to="/">
           - TOP -


### PR DESCRIPTION
ストーリー
https://www.pivotaltracker.com/story/show/183895685

タスク一覧(トップ)画面とチーム画面でタスク表示のコードが重複していた部分を
Tasksコンポーネントとして切り出しました。

参考
- https://github.com/apollographql/apollo-feature-requests/issues/165